### PR TITLE
Reassign left Option (⌥) key to Normal.

### DIFF
--- a/machines/joshuas-imac/com.googlecode.iterm2.plist
+++ b/machines/joshuas-imac/com.googlecode.iterm2.plist
@@ -4105,7 +4105,7 @@
 			<key>Only The Default BG Color Uses Transparency</key>
 			<false/>
 			<key>Option Key Sends</key>
-			<integer>2</integer>
+			<integer>0</integer>
 			<key>Prompt Before Closing 2</key>
 			<integer>0</integer>
 			<key>Reduce Flicker</key>


### PR DESCRIPTION
* This is useful for typing certain special characters, such as the em dash
(—).